### PR TITLE
Updated for macOS build compatibility.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
-.idea/
-__pycache__
-datafiles/
+.vscode/
+build/
+
 simDER
-build
-cmake-build-debug
-robotDescription.cpp
+datafiles/
 option.txt
+src/robotDescription.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,63 +1,94 @@
 cmake_minimum_required(VERSION 3.11)
 project(dismech-rods)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Release)
-#set(CMAKE_BUILD_TYPE Debug)
-set(CMAKE_CXX_FLAGS "-Wno-deprecated-declarations -fopenmp")
+
+# set(CMAKE_BUILD_TYPE Debug)
+set(CMAKE_CXX_FLAGS "-Wno-deprecated-declarations")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "../")
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+
+# Per https://eigen.tuxfamily.org/dox/TopicUsingIntelMKL.html eigen should be used
+# with MKL LAPACK only with lp64 set. The default may be ILP64, which we don't want.
+set(MKL_INTERFACE_FULL intel_lp64)
+
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 
+include(CheckIncludeFileCXX)
+
+add_definitions(-DEIGEN_USE_MKL_ALL)
+
 find_package(SymEngine REQUIRED)
-find_package(Eigen3 3.4 REQUIRED)
-find_package(OpenGL REQUIRED)
 find_package(GLUT REQUIRED)
-find_package(MKL REQUIRED)
+find_package(OpenGL REQUIRED)
+find_package(MKL CONFIG REQUIRED)
+find_package(LAPACK REQUIRED)
+find_package(BLAS REQUIRED)
+find_package(Threads REQUIRED)
+find_package(Eigen3 3.4 REQUIRED)
+find_package(OpenMP)
+
+if(${HAVE_SYMENGINE_LLVM})
+    message(STATUS "Testing SymEngine LLVM & SBML support - found")
+else()
+    message(WARNING "SymEngine library is missing LLVM and/or SBML support")
+    message(WARNING "${SYMENGINE_LLVM_ERROR_LOG}")
+endif()
+
+check_include_file_cxx("filesystem" HAVE_STD_FILESYSTEM)
+
+if(NOT ${HAVE_STD_FILESYSTEM})
+    message(ERROR "Missing std::filesystem.")
+endif()
 
 include_directories(${SYMENGINE_INCLUDE_DIRS}
-        ${EIGEN_INCLUDE_DIRS}
-        ${OPENGL_INCLUDE_DIRS}
-        ${GLUT_INCLUDE_DIRS}
-        ${MKL_INCLUDE_DIR})
+    ${EIGEN_INCLUDE_DIRS}
+    ${OPENGL_INCLUDE_DIRS}
+    ${GLUT_INCLUDE_DIRS}
+    MKL::MKL)
 
 link_directories(${MKL_LIBRARY_DIR})
 
 add_executable(simDER
-        src/main.cpp
-        src/world.cpp
-        src/robotDescription.cpp
-        src/initialization/setInput.cpp
-        src/rod_mechanics/elasticRod.cpp
-        src/rod_mechanics/elasticStretchingForce.cpp
-        src/rod_mechanics/elasticBendingForce.cpp
-        src/rod_mechanics/elasticTwistingForce.cpp
-        src/rod_mechanics/externalGravityForce.cpp
-        src/rod_mechanics/dampingForce.cpp
-        src/rod_mechanics/inertialForce.cpp
-        src/rod_mechanics/timeStepper.cpp
-        src/rod_mechanics/symbolicEquations.cpp
-        src/rod_mechanics/floorContactForce.cpp
-        src/rod_mechanics/elasticJoint.cpp
-#        src/rod_mechanics/collisionDetector.cpp
-#        src/rod_mechanics/contactPotentialIMC.cpp
-        src/logging/worldLogger.cpp
-        src/simulation_environments/derSimulationEnvironment.cpp
-        src/simulation_environments/headlessDERSimulationEnvironment.cpp
-        src/simulation_environments/openglDERSimulationEnvironment.cpp
-        )
+    src/main.cpp
+    src/world.cpp
+    src/robotDescription.cpp
+    src/initialization/setInput.cpp
+    src/rod_mechanics/elasticRod.cpp
+    src/rod_mechanics/elasticStretchingForce.cpp
+    src/rod_mechanics/elasticBendingForce.cpp
+    src/rod_mechanics/elasticTwistingForce.cpp
+    src/rod_mechanics/externalGravityForce.cpp
+    src/rod_mechanics/dampingForce.cpp
+    src/rod_mechanics/inertialForce.cpp
+    src/rod_mechanics/timeStepper.cpp
+    src/rod_mechanics/symbolicEquations.cpp
+    src/rod_mechanics/floorContactForce.cpp
+    src/rod_mechanics/elasticJoint.cpp
 
-target_link_libraries(simDER
-        ${SYMENGINE_LIBRARIES}
-        ${OPENGL_LIBRARIES}
-        ${GLUT_LIBRARIES}
-        ${MKL_LIBRARIES}
-        Eigen3::Eigen
-        lapack
-        gfortran
-        pthread
-        rt
-        m
-        stdc++fs
+    # src/rod_mechanics/collisionDetector.cpp
+    # src/rod_mechanics/contactPotentialIMC.cpp
+    src/logging/worldLogger.cpp
+    src/simulation_environments/derSimulationEnvironment.cpp
+    src/simulation_environments/headlessDERSimulationEnvironment.cpp
+    src/simulation_environments/openglDERSimulationEnvironment.cpp
 )
+target_link_libraries(simDER PRIVATE
+    ${OPENGL_LIBRARIES}
+    ${GLUT_LIBRARIES}
+    MKL::MKL
+    Eigen3::Eigen
+    ${LAPACK_LIBRARIES}
+    ${BLAS_LIBRARIES}
+
+    # gfortran
+    Threads::Threads
+    m
+    ${SYMENGINE_LIBRARIES})
+
+if(OpenMP_CXX_FOUND)
+    target_link_libraries(simDER PUBLIC OpenMP::OpenMP_CXX)
+endif()

--- a/README.md
+++ b/README.md
@@ -3,9 +3,21 @@
 ### How to Use
 
 ### Dependencies
-Install the following C++ dependencies:
-- [Eigen](http://eigen.tuxfamily.org/index.php?title=Main_Page)
+
+There are some dependencies required prior to compilation.
+Instructions for macOS and Ubuntu are similar (presented below).
+For other operating systems you should be able to modify the commands below appropriately.
+
+- **macOS**: Because this uses the MKL, it's not certain to run on Apple silicone.
+- **macOS**: If you're running a mac, it's highly recommended you use a package manager like [MacPorts](https://www.macports.org/install.php) or [homebrew](https://brew.sh/). Instructions below are for MacPorts.
+- **Note**: Some of these packages are installed to the system library for convenience. You may want to install locally to e.g., `~/.local` to avoid conflicts with system libraries. Add the `cmake` flag: `-D CMAKE_INSTALL_PREFIX=~/.local`. Then `sudo` is not required to install. You'll need to ensure subsequent builds know where to find the build libraries.
+
+- X11
+  - An X11 (xorg) server is necessary to use the `freeglut` library. This exists already on Linux.
+  - **macOS**: This can be installed with MacPorts: `sudo port install xorg-server`. Then log out and back in.
+- [Eigen 3.4.0](http://eigen.tuxfamily.org/index.php?title=Main_Page)
   - Eigen is used for various linear algebra operations.
+  - **macOS**: You can install this version with MacPorts: `sudo port install eigen3`. Otherwise, build instructions are below.
   - IMC is built with Eigen version 3.4.0 which can be downloaded [here](https://gitlab.com/libeigen/eigen/-/releases/3.4.0). After downloading the source code, install through cmake as follows.
     ```bash
     cd eigen-3.4.0 && mkdir build && cd build
@@ -14,26 +26,28 @@ Install the following C++ dependencies:
     ```
 - [SymEngine](https://github.com/symengine/symengine)
   - SymEngine is used for symbolic differentiation and function generation.
-  - Before installing SymEngine, LLVM is required which can be installed through apt.
-    ```bash
-    sudo apt-get install llvm
-    ```
+  - **macOS**: SymEngine with LLVM can be installed with MacPorts: `sudo port install symengine`.
+  - Before installing SymEngine, LLVM is required which can be installed most easily via a package manager:
+    - **Ubuntu**: `sudo apt-get install llvm`
+    - **macOS**: `sudo port install llvm-15`
   - Afterwards, install SymEngine from source using the following commands.
     ```bash
-    git clone https://github.com/symengine/symengine    
+    git clone https://github.com/symengine/symengine
     cd symengine && mkdir build && cd build
-    cmake -DWITH_LLVM=on ..
+    cmake -D WITH_LLVM=on -D BUILD_BENCHMARKS=off -D BUILD_TESTS=off ..
     make -j4
     sudo make install
     ```
+  - **macOS**: You'll need to provide the LLVM root to the build with `-D CMAKE_PREFIX_PATH=/opt/local/libexec/llvm-15` (if installed via MacPorts).
 - [Intel oneAPI Math Kernel Library (oneMKL)](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl-download.html?operatingsystem=linux&distributions=webdownload&options=online)
   - Necessary for access to Pardiso, which is used as a sparse matrix solver.
   - Intel MKL is also used as the BLAS / LAPACK backend for Eigen.
-  - If you are using Linux, follow the below steps. Otherwise, click the link above for your OS.
+  - **macOS**: Download from [Intel](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl-download.html) and use the install script.
+  - **Ubuntu**: Follow the below steps.
     ```bash
     cd /tmp
     wget https://registrationcenter-download.intel.com/akdlm/irc_nas/18483/l_onemkl_p_2022.0.2.136.sh
-    
+
     # This runs an installer, simply follow the instructions.
     sudo sh ./l_onemkl_p_2022.0.2.136.sh
     ```
@@ -45,10 +59,10 @@ Install the following C++ dependencies:
 - [OpenGL / GLUT](https://www.opengl.org/)
   - OpenGL / GLUT is used for rendering the knot through a simple graphic.
   - Simply install through apt package manager:
-      ```bash
-    sudo apt-get install libglu1-mesa-dev freeglut3-dev mesa-common-dev
-    ```
-- Lapack (*usually preinstalled on your computer*)
+    - **Ubuntu**: `sudo apt-get install libglu1-mesa-dev freeglut3-dev mesa-common-dev`
+    - **macOS**: `sudo port install freeglut pkgconfig` (Note: `pkgconfig` is necessary to avoid finding system GLUT instead of `freeglut`.)
+
+- Lapack (*included in MKL*)
 
 ***
 ### Compiling
@@ -75,7 +89,7 @@ Specifiable parameters are as follows (we use SI units):
 - ```youngM``` - Young's modulus.
 - ```Poisson``` - Poisson ratio.
 - ```tol``` and ```stol``` - Small numbers used in solving the linear system. Fraction of a percent, e.g. 1.0e-3, is often a good choice.
-- ```maxIter``` - Maximum number of iterations allowed before the solver quits. 
+- ```maxIter``` - Maximum number of iterations allowed before the solver quits.
 - ```gVector``` - 3x1 vector specifying acceleration due to gravity.
 - ```viscosity``` - Viscosity for applying damping forces.
 - ```render (0 or 1) ```- Flag indicating whether OpenGL visualization should be rendered.

--- a/src/eigenIncludes.h
+++ b/src/eigenIncludes.h
@@ -1,4 +1,3 @@
-#define EIGEN_USE_MKL_ALL
 #include <iostream>
 #include <Eigen/Dense>
 #include <Eigen/Geometry>

--- a/src/logging/worldLogger.cpp
+++ b/src/logging/worldLogger.cpp
@@ -13,7 +13,7 @@
 #include <stdexcept>
 #include <time.h> // for the file name of the log file
 // for the folder creation
-namespace fs = std::experimental::filesystem;
+namespace fs = std::filesystem;
 
 // Constructor: creates the file name, stores locals
 worldLogger::worldLogger(std::string fileNamePrefix, std::string logfile_base, std::ofstream& df, shared_ptr<world> w, int per) :

--- a/src/logging/worldLogger.h
+++ b/src/logging/worldLogger.h
@@ -18,7 +18,7 @@
 
 // the C++ standard library
 #include <fstream> // for writing to a file
-#include <experimental/filesystem> // for creating the directory for the log file
+#include <filesystem> // for creating the directory for the log file
 
 // Abstract class: although we'll do a constructor to set the
 // path prefix variable, children have to define what to log and how.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,14 +2,8 @@
  * simDER
  * simDER stands for "[sim]plified [D]iscrete [E]lastic [R]ods"
  * Dec 2017
- * This code is based on previous iterations. 
+ * This code is based on previous iterations.
  * */
-
-//This line is for mac
-//#include <GLUT/glut.h>
-
-//This is for linux
-#include <GL/glut.h>
 
 #include <iostream>
 #include "eigenIncludes.h"

--- a/src/rod_mechanics/timeStepper.cpp
+++ b/src/rod_mechanics/timeStepper.cpp
@@ -113,8 +113,8 @@ void timeStepper::update()
 
 void timeStepper::pardisoSolver()
 {
-    int n = freeDOF;
-    int ia[n+1];
+    MKL_INT n = freeDOF;
+    MKL_INT ia[n+1];
     ia[0] = 1;
 
     int temp = 0;
@@ -130,7 +130,7 @@ void timeStepper::pardisoSolver()
         ia[i+1] = temp+1;
     }
 
-    int ja[ia[n]];
+    MKL_INT ja[ia[n]];
     double a[ia[n]];
     temp = 0;
 

--- a/src/simulation_environments/derSimulationEnvironment.h
+++ b/src/simulation_environments/derSimulationEnvironment.h
@@ -34,7 +34,7 @@ class derSimulationEnvironment
      */
     derSimulationEnvironment(shared_ptr<world> m_world, int m_cmdline_per);
     derSimulationEnvironment(shared_ptr<world> m_world, int m_cmdline_per, shared_ptr<worldLogger> m_logger);
-    ~derSimulationEnvironment();
+    virtual ~derSimulationEnvironment();
 
     /**
      * Setup function, called SEPARATELY, as needed according to specific environment

--- a/src/simulation_environments/openglDERSimulationEnvironment.cpp
+++ b/src/simulation_environments/openglDERSimulationEnvironment.cpp
@@ -11,6 +11,10 @@
 // all includes should be in header
 #include "openglDERSimulationEnvironment.h"
 
+// Includes for GLUT.
+// We need the one with "ext" to get glutLeaveMainLoop
+#include <GL/freeglut.h>
+
 // the callbacks for openGL.
 // Note this is a C function now
 extern "C" void keyHandler(unsigned char key, int x, int y)

--- a/src/simulation_environments/openglDERSimulationEnvironment.h
+++ b/src/simulation_environments/openglDERSimulationEnvironment.h
@@ -14,17 +14,6 @@
 // Subclass of simulation environment
 #include "derSimulationEnvironment.h"
 
-// Includes for GLUT.
-
-//This line is for mac
-//#include <GLUT/glut.h>
-
-//This is for linux
-// #include <GL/glut.h>
-// We need the one with "ext" to get glutLeaveMainLoop
-#include <GL/freeglut.h>
-
-
 // // OpenGL calls this function to timestep the simulation and update the window.
 // // GLUT is in C so these need to either be static (nope!) or extern "C" methods.
 // extern "C" void derOpenGLDisplay();


### PR DESCRIPTION
Notable changes:

- I replaced a few hard-coded or implicit configurations with `find_package` type defines.
- Commented out `gfortran`. Is it used somewhere?
- Made OpenMP optional (it doesn't seem to be used anyway, based on the code and `run.sh`). Mac clang does not have OMP support (-_-'). You can install an alternate clang with such support, but it seems unnecessary to recommend that if you're sending in the `OMP_NUM_THREADS=1` variable anyway.