### PR TITLE
Refactor environments to now be able to step simulations via API

### DIFF
--- a/py_examples/helix_case/helixExample.py
+++ b/py_examples/helix_case/helixExample.py
@@ -53,4 +53,5 @@ add_force(gravity_force)
 
 # Initialize and run the simulation
 sim_manager.initialize(sys.argv)
-sim_manager.run()
+while not sim_manager.simulation_completed():
+    sim_manager.step_simulation()

--- a/py_examples/spider_case/spiderExample.py
+++ b/py_examples/spider_case/spiderExample.py
@@ -27,6 +27,7 @@ sim_params.ftol = 1e-3
 
 render_params.render_scale = 5.0
 render_params.show_mat_frames = True
+render_params.renderer = py_dismech.OPENGL
 
 if SIM_FAST:
     sim_params.dt = 2.5e-3
@@ -85,4 +86,5 @@ add_force(floor_contact_force)
 
 # Initialize and run the simulation
 sim_manager.initialize(sys.argv)
-sim_manager.run()
+while not sim_manager.simulation_completed():
+    sim_manager.step_simulation()

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -71,8 +71,17 @@ public:
                 throw std::runtime_error("Unknown renderer type provided.");
         }
     }
+    bool simulationCompleted() {
+        return !my_world->simulationRunning();
+    }
 
-    void run() {
+    void stepSimulation() {
+        if (env) {
+            env->stepSimulation();
+        }
+    }
+
+    void runSimulation() {
         if (env) {
             env->runSimulation();
         }
@@ -94,7 +103,9 @@ PYBIND11_MODULE(py_dismech, m) {
             // Call the original function
             self.initialize(argc, argv.data());
         })
-        .def("run", &simulationManager::run)
+        .def("simulation_completed", &simulationManager::simulationCompleted)
+        .def("step_simulation", &simulationManager::stepSimulation)
+        .def("run_simulation", &simulationManager::runSimulation)
         .def_readwrite("soft_robots", &simulationManager::soft_robots)
         .def_readwrite("forces", &simulationManager::forces)
         .def_readwrite("sim_params", &simulationManager::sim_params)

--- a/src/simulation_environments/derSimulationEnvironment.h
+++ b/src/simulation_environments/derSimulationEnvironment.h
@@ -40,6 +40,9 @@ class derSimulationEnvironment
      */
     virtual void runSimulation() = 0;
 
+    // Step the simulation one time step.
+    virtual void stepSimulation() = 0;
+
     protected:
 
     // A helper, to make the command line output (via cmdline_per) general to all simulation environments.

--- a/src/simulation_environments/headlessDERSimulationEnvironment.cpp
+++ b/src/simulation_environments/headlessDERSimulationEnvironment.cpp
@@ -12,36 +12,26 @@ headlessDERSimulationEnvironment::headlessDERSimulationEnvironment(const shared_
 headlessDERSimulationEnvironment::~headlessDERSimulationEnvironment() = default;
 
 
-// Loop while world has yet to reach its final time.
-void headlessDERSimulationEnvironment::runSimulation()
-{
-	// let our users know not to expect a GUI
-    std::cout << "Using a headless simulation environment. Reporting back at an interval of " << cmdline_per << " msec." << std::endl;
-	// Before the simulation starts: log the x0 state.
-	if(is_logging){
-		logger_p->logWorldData();
-	}
-	// loop until done. The world knows its max time.
-	while ( w_p->simulationRunning() > 0)
-	{
-		// catch convergence errors
-		try {
-			w_p->updateTimeStep(); // update time step
-		}
-		catch(std::runtime_error& excep){
-            std::cout << "Caught a runtime_error when trying to world->updateTimeStep: " << excep.what() << std::endl;
-            std::cout << "Attempting clean shutdown..." << std::endl;
-			// superclass has the method
-			cleanShutdown();
-			// ugly to return here, but that's life
-			return;
-		}
+void headlessDERSimulationEnvironment::stepSimulation() {
+    try {
+        w_p->updateTimeStep();
+    }
+    catch(std::runtime_error& excep){
+        std::cout << "Caught a runtime_error when trying to world->updateTimeStep: " << excep.what() << std::endl;
+        std::cout << "Attempting clean shutdown..." << std::endl;
+        cleanShutdown();
+        return;
+    }
 
-		// log if specified.
-		if(is_logging){
-			logger_p->logWorldData();
-		}
-		// periodically report to the command line.
-		cmdlineOutputHelper();
-	}
+    if(is_logging){
+        logger_p->logWorldData();
+    }
+
+    cmdlineOutputHelper();
+}
+
+void headlessDERSimulationEnvironment::runSimulation() {
+	while (w_p->simulationRunning()) {
+        stepSimulation();
+    }
 }

--- a/src/simulation_environments/headlessDERSimulationEnvironment.h
+++ b/src/simulation_environments/headlessDERSimulationEnvironment.h
@@ -12,6 +12,7 @@ class headlessDERSimulationEnvironment : public derSimulationEnvironment
                                      const shared_ptr<worldLogger>& logger);
     ~headlessDERSimulationEnvironment() override;
 
+    void stepSimulation() override;
     void runSimulation() override;
 };
 

--- a/src/simulation_environments/magnumDERSimulationEnvironment.h
+++ b/src/simulation_environments/magnumDERSimulationEnvironment.h
@@ -88,6 +88,7 @@ public:
     explicit magnumDERSimulationEnvironment(const shared_ptr<world>& m_world, const renderParams& render_params,
                    const shared_ptr<worldLogger>& logger, int argc, char **argv);
 
+    void stepSimulation() override;
     void runSimulation() override;
 
 private:
@@ -126,6 +127,10 @@ private:
     std::vector<std::unique_ptr<Object3D>> edges;
     std::vector<std::unique_ptr<CapsuleDrawable>> capsule_drawables;
     std::vector<std::unique_ptr<SceneGraph::Drawable3D>> misc_drawables;
+
+    PluginManager::Manager<Trade::AbstractImageConverter> manager;
+    Containers::Pointer<Trade::AbstractImageConverter> converter;
+    bool record_frames;
 
     Float last_depth;
     Vector2i last_position{-1};

--- a/src/simulation_environments/openglDERSimulationEnvironment.cpp
+++ b/src/simulation_environments/openglDERSimulationEnvironment.cpp
@@ -1,6 +1,5 @@
 #include "openglDERSimulationEnvironment.h"
 #include <GL/freeglut.h>
-#include <ctime>
 
 // the callbacks for openGL.
 // Note this is a C function now
@@ -27,12 +26,6 @@ openglDERSimulationEnvironment::openglDERSimulationEnvironment(const shared_ptr<
     opengl_is_logging = logger != nullptr;
     opengl_logger = logger;
 
-}
-
-openglDERSimulationEnvironment::~openglDERSimulationEnvironment() = default;
-
-/* Initialize OpenGL Graphics */
-void openglDERSimulationEnvironment::initGL() {
     // Initialize GLUT
     glutInit(&argc_main, argv_main);
     // When the window closes, return control back to main
@@ -50,7 +43,6 @@ void openglDERSimulationEnvironment::initGL() {
 
     glLoadIdentity();
     gluLookAt(0.05, 0.05, 0.1, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0);
-//	gluLookAt(0.00, 0.00, 0.3, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0);
     glPushMatrix();
 
     // Other OpenGL setup:
@@ -66,160 +58,144 @@ void openglDERSimulationEnvironment::initGL() {
     }
 }
 
+openglDERSimulationEnvironment::~openglDERSimulationEnvironment() = default;
+
+
 void openglDERSimulationEnvironment::derOpenGLDisplay(void) {
-    // openglWorld_p is static.
-    // world knows its max time from setInput
-    clock_t t = clock();
-    while (opengl_world->simulationRunning() > 0) {
-        //  Clear screen and Z-buffer
-        glClear(GL_COLOR_BUFFER_BIT);
+    // Step the world forward. This takes care of the SMAs, controller, rod, etc., ...
+    try {
+        opengl_world->updateTimeStep(); // update time step
+    }
+    catch (std::runtime_error &excep) {
+        std::cout << "Caught a runtime_error when trying to world->updateTimeStep: " << excep.what()
+                  << std::endl;
+        std::cout << "Attempting clean shutdown..." << std::endl;
+        cleanShutdown(opengl_logger, opengl_is_logging);
+        glutLeaveMainLoop();
+    }
 
-        // draw axis
-        float axis_len = 1;
-        glLineWidth(0.5);
+    // log if specified.
+    if (opengl_is_logging) {
+        opengl_logger->logWorldData();
+    }
 
-        // Draw axes.
-        glBegin(GL_LINES);
-        glColor3f(1.0, 0.0, 0.0);
-        glVertex3f(0.0, 0.0, 0.0);
-        glVertex3f(axis_len, 0.0, 0.0);
-        glColor3f(0.0, 1.0, 0.0);
-        glVertex3f(0.0, 0.0, 0.0);
-        glVertex3f(0.0, axis_len, 0.0);
-        glColor3f(0.0, 0.0, 1.0);
-        glVertex3f(0.0, 0.0, 0.0);
-        glVertex3f(0.0, 0.0, axis_len);
-        glEnd();
+    // The helper from our superclass handles command line output.
+    cmdlineOutputHelper(opengl_world, opengl_cmdline_per);
 
-        // much thicker lines
-        glLineWidth(4.0);
+    // Clear screen and Z-buffer
+    glClear(GL_COLOR_BUFFER_BIT);
 
-        // Draw the rod
-        glBegin(GL_LINES);
-        glColor3f(0.0, 0.0, 0.0);
-        int limb_idx = 0;
-        for (const auto &limb: opengl_world->soft_robots->limbs) {
-            for (int i = 0; i < limb->ne; i++) {
-                if (limb->isEdgeJoint[i] == 0) {
-                    glVertex3f(opengl_world->getCoordinate(4 * i, limb_idx) * render_scale,
-                               opengl_world->getCoordinate(4 * i + 1, limb_idx) * render_scale,
-                               opengl_world->getCoordinate(4 * i + 2, limb_idx) * render_scale);
-                    glVertex3f(opengl_world->getCoordinate(4 * (i + 1), limb_idx) * render_scale,
-                               opengl_world->getCoordinate(4 * (i + 1) + 1, limb_idx) * render_scale,
-                               opengl_world->getCoordinate(4 * (i + 1) + 2, limb_idx) * render_scale);
-                }
-            }
-            limb_idx++;
-        }
+    // draw axis
+    float axis_len = 1;
+    glLineWidth(0.5);
 
-        // Draw joints
-        glColor3f(0.0, 0.0, 1.0);
-        int n, l;
-        for (const auto &joint: opengl_world->soft_robots->joints) {
-            for (int i = 0; i < joint->ne; i++) {
-                n = joint->connected_nodes[i].first;
-                l = joint->connected_nodes[i].second;
-                glVertex3f(opengl_world->getCoordinate(4 * n, l) * render_scale,
-                           opengl_world->getCoordinate(4 * n + 1, l) * render_scale,
-                           opengl_world->getCoordinate(4 * n + 2, l) * render_scale);
-                glVertex3f(joint->x(0) * render_scale,
-                           joint->x(1) * render_scale,
-                           joint->x(2) * render_scale);
-            }
-        }
-        glEnd();
+    // Draw axes.
+    glBegin(GL_LINES);
+    glColor3f(1.0, 0.0, 0.0);
+    glVertex3f(0.0, 0.0, 0.0);
+    glVertex3f(axis_len, 0.0, 0.0);
+    glColor3f(0.0, 1.0, 0.0);
+    glVertex3f(0.0, 0.0, 0.0);
+    glVertex3f(0.0, axis_len, 0.0);
+    glColor3f(0.0, 0.0, 1.0);
+    glVertex3f(0.0, 0.0, 0.0);
+    glVertex3f(0.0, 0.0, axis_len);
+    glEnd();
 
-        // Draw material directors
-        if (show_mat_frames) {
-            glLineWidth(2.5);
-            glBegin(GL_LINES);
-            limb_idx = 0;
-            double x, y, z;
-            VectorXd m1, m2;
-            for (const auto &limb: opengl_world->soft_robots->limbs) {
-                for (int i = 0; i < limb->ne; i++) {
-                    if (limb->isEdgeJoint[i] == 0) {
-                        x = 0.5 * render_scale * (opengl_world->getCoordinate(4 * i, limb_idx) +
-                                                  opengl_world->getCoordinate(4 * (i + 1), limb_idx));
-                        y = 0.5 * render_scale * (opengl_world->getCoordinate(4 * i + 1, limb_idx) +
-                                                  opengl_world->getCoordinate(4 * (i + 1) + 1, limb_idx));
-                        z = 0.5 * render_scale * (opengl_world->getCoordinate(4 * i + 2, limb_idx) +
-                                                  opengl_world->getCoordinate(4 * (i + 1) + 2, limb_idx));
-                        m1 = 0.05 * opengl_world->getM1(i, limb_idx);
-                        m2 = 0.05 * opengl_world->getM2(i, limb_idx);
-                        glColor3f(1.0, 0.0, 0.0);
-                        glVertex3f(x, y, z);
-                        glVertex3f(x + m1[0], y + m1[1], z + m1[2]);
-                        glColor3f(0.5, 0.0, 1.0);
-                        glVertex3f(x, y, z);
-                        glVertex3f(x + m2[0], y + m2[1], z + m2[2]);
-                    }
-                }
-                limb_idx++;
-            }
-            glEnd();
-        }
+    // much thicker lines
+    glLineWidth(4.0);
 
-        // Draw nodes
-        glPointSize(4.0);
-        glBegin(GL_POINTS);
-        glColor3f(0.0, 1.0, 0.0);
-        limb_idx = 0;
-        for (const auto &limb: opengl_world->soft_robots->limbs) {
-            for (int i = 0; i < limb->nv; i++) {
+    // Draw the rod
+    glBegin(GL_LINES);
+    glColor3f(0.0, 0.0, 0.0);
+    int limb_idx = 0;
+    for (const auto &limb: opengl_world->soft_robots->limbs) {
+        for (int i = 0; i < limb->ne; i++) {
+            if (limb->isEdgeJoint[i] == 0) {
                 glVertex3f(opengl_world->getCoordinate(4 * i, limb_idx) * render_scale,
                            opengl_world->getCoordinate(4 * i + 1, limb_idx) * render_scale,
                            opengl_world->getCoordinate(4 * i + 2, limb_idx) * render_scale);
-//                }
+                glVertex3f(opengl_world->getCoordinate(4 * (i + 1), limb_idx) * render_scale,
+                           opengl_world->getCoordinate(4 * (i + 1) + 1, limb_idx) * render_scale,
+                           opengl_world->getCoordinate(4 * (i + 1) + 2, limb_idx) * render_scale);
+            }
+        }
+        limb_idx++;
+    }
+
+    // Draw joints
+    glColor3f(0.0, 0.0, 1.0);
+    int n, l;
+    for (const auto &joint: opengl_world->soft_robots->joints) {
+        for (int i = 0; i < joint->ne; i++) {
+            n = joint->connected_nodes[i].first;
+            l = joint->connected_nodes[i].second;
+            glVertex3f(opengl_world->getCoordinate(4 * n, l) * render_scale,
+                       opengl_world->getCoordinate(4 * n + 1, l) * render_scale,
+                       opengl_world->getCoordinate(4 * n + 2, l) * render_scale);
+            glVertex3f(joint->x(0) * render_scale,
+                       joint->x(1) * render_scale,
+                       joint->x(2) * render_scale);
+        }
+    }
+    glEnd();
+
+    // Draw material directors
+    if (show_mat_frames) {
+        glLineWidth(2.5);
+        glBegin(GL_LINES);
+        limb_idx = 0;
+        double x, y, z;
+        VectorXd m1, m2;
+        for (const auto &limb: opengl_world->soft_robots->limbs) {
+            for (int i = 0; i < limb->ne; i++) {
+                if (limb->isEdgeJoint[i] == 0) {
+                    x = 0.5 * render_scale * (opengl_world->getCoordinate(4 * i, limb_idx) +
+                                              opengl_world->getCoordinate(4 * (i + 1), limb_idx));
+                    y = 0.5 * render_scale * (opengl_world->getCoordinate(4 * i + 1, limb_idx) +
+                                              opengl_world->getCoordinate(4 * (i + 1) + 1, limb_idx));
+                    z = 0.5 * render_scale * (opengl_world->getCoordinate(4 * i + 2, limb_idx) +
+                                              opengl_world->getCoordinate(4 * (i + 1) + 2, limb_idx));
+                    m1 = 0.05 * opengl_world->getM1(i, limb_idx);
+                    m2 = 0.05 * opengl_world->getM2(i, limb_idx);
+                    glColor3f(1.0, 0.0, 0.0);
+                    glVertex3f(x, y, z);
+                    glVertex3f(x + m1[0], y + m1[1], z + m1[2]);
+                    glColor3f(0.5, 0.0, 1.0);
+                    glVertex3f(x, y, z);
+                    glVertex3f(x + m2[0], y + m2[1], z + m2[2]);
+                }
             }
             limb_idx++;
         }
         glEnd();
-
-
-        glFlush();
-
-        // Step the world forward. This takes care of the SMAs, controller, rod, etc., ...
-        // openglWorld_p->updateTimeStep();
-        // catch convergence errors
-        try {
-            opengl_world->updateTimeStep(); // update time step
-        }
-        catch (std::runtime_error &excep) {
-            std::cout << "Caught a runtime_error when trying to world->updateTimeStep: " << excep.what()
-                      << std::endl;
-            std::cout << "Attempting clean shutdown..." << std::endl;
-            // superclass has the method
-            cleanShutdown(opengl_logger, opengl_is_logging);
-            // ugly to return here, but that's life
-            // exit(1);
-            // return;
-            // FreeGLUT has a routine for actually stopping the GUI and returning cleanly
-            glutLeaveMainLoop();
-        }
-
-        // log if specified.
-        if (opengl_is_logging) {
-            opengl_logger->logWorldData();
-        }
-
-        // The helper from our superclass handles command line output.
-        cmdlineOutputHelper(opengl_world, opengl_cmdline_per);
-
-        // sleep(0.1);
     }
-    cout << "total time " << (double)(clock() -  t) / CLOCKS_PER_SEC << endl;
-    // exit(1);
-    // return;
-    // FreeGLUT has a routine for actually stopping the GUI and returning cleanly
-    glutLeaveMainLoop();
+
+    // Draw nodes
+    glPointSize(4.0);
+    glBegin(GL_POINTS);
+    glColor3f(0.0, 1.0, 0.0);
+    limb_idx = 0;
+    for (const auto &limb: opengl_world->soft_robots->limbs) {
+        for (int i = 0; i < limb->nv; i++) {
+            glVertex3f(opengl_world->getCoordinate(4 * i, limb_idx) * render_scale,
+                       opengl_world->getCoordinate(4 * i + 1, limb_idx) * render_scale,
+                       opengl_world->getCoordinate(4 * i + 2, limb_idx) * render_scale);
+        }
+        limb_idx++;
+    }
+    glEnd();
+    glFlush();
 }
 
-// Simply start up openGL.
+
+void openglDERSimulationEnvironment::stepSimulation() {
+    glutMainLoopEvent();
+    glutPostRedisplay();
+}
+
 void openglDERSimulationEnvironment::runSimulation() {
-    std::cout << "Using a graphical simulation environment. Opening an openGL window..." << std::endl;
-    // First, setup the openGL window
-    initGL();
-    // then start up openGL.
-    glutMainLoop();
+    while (opengl_world->simulationRunning()) {
+        stepSimulation();
+    }
 }

--- a/src/simulation_environments/openglDERSimulationEnvironment.h
+++ b/src/simulation_environments/openglDERSimulationEnvironment.h
@@ -22,22 +22,12 @@ class openglDERSimulationEnvironment : public derSimulationEnvironment
                                    const shared_ptr<worldLogger>& logger, int argc, char **argv);
     ~openglDERSimulationEnvironment() override;
 
-    /**
-     * Setup function, called SEPARATELY.
-     */
-    // void setup();
-
-    /**
-     * Start the simulation!
-     */
     void runSimulation() override;
+    void stepSimulation() override;
     static bool show_mat_frames;
     static double render_scale;
 
     protected:
-
-    // helper that initializes the OpenGL window
-    void initGL();
 
     // OpenGL calls this function to timestep the simulation and update the window.
     // GLUT is in C. A static method works here: uses openglWorld_p and openglWorldLogger_p.


### PR DESCRIPTION
This PR now adds the `stepSimulation` (`step_simulation` in python) function in the API. Previously, the simulation loop was automatically triggered via `runSimulation`, disallowing any logic from occurring from the Python side in between time steps. This now remedies that.