### PR TITLE
Add pybind getters for limb pos, vel, theta

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -133,10 +133,10 @@ PYBIND11_MODULE(py_dismech, m) {
         .def("step_simulation", py::overload_cast<>(&simulationManager::stepSimulation))
         .def("step_simulation", py::overload_cast<py::dict>(&simulationManager::stepSimulation))
         .def("run_simulation", &simulationManager::runSimulation)
-        .def_readwrite("soft_robots", &simulationManager::soft_robots)
-        .def_readwrite("forces", &simulationManager::forces)
-        .def_readwrite("sim_params", &simulationManager::sim_params)
-        .def_readwrite("render_params", &simulationManager::render_params)
+        .def_readonly("soft_robots", &simulationManager::soft_robots)
+        .def_readonly("forces", &simulationManager::forces)
+        .def_readonly("sim_params", &simulationManager::sim_params)
+        .def_readonly("render_params", &simulationManager::render_params)
         .def_readwrite("logger", &simulationManager::logger);
 
     py::class_<softRobots, std::shared_ptr<softRobots>>(m, "SoftRobots")
@@ -160,9 +160,21 @@ PYBIND11_MODULE(py_dismech, m) {
              py::arg("velocities"))
         .def("setup", &softRobots::setup)
         .def("addController", &softRobots::addController, py::arg("controller"))
-        .def_readwrite("limbs", &softRobots::limbs)
-        .def_readwrite("joints", &softRobots::joints)
-        .def_readwrite("controllers", &softRobots::controllers);
+        .def_readonly("limbs", &softRobots::limbs, py::return_value_policy::reference_internal)
+        .def_readonly("joints", &softRobots::joints,
+                      py::return_value_policy::reference_internal)
+        .def_readonly("controllers", &softRobots::controllers);
+
+    py::class_<elasticRod, std::shared_ptr<elasticRod>>(m, "ElasticRod")
+        .def("getVertexPos", &elasticRod::getVertex)
+        .def("getVertexVel", &elasticRod::getVelocity)
+        .def("getEdgeTheta", &elasticRod::getTheta)
+        .def("getVertices", &elasticRod::getVertices)
+        .def("getVelocities", &elasticRod::getVelocities)
+        .def("getThetas", &elasticRod::getThetas)
+        .def("freeVertexBoundaryCondition", &elasticRod::freeVertexBoundaryCondition)
+        .def("setVertexBoundaryCondition", &elasticRod::setVertexBoundaryCondition)
+        .def("setThetaBoundaryCondition", &elasticRod::setThetaBoundaryCondition);
 
     // =============================== Enum Definitions =========================================
     py::enum_<integratorMethod>(m, "IntegratorMethod")

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -159,11 +159,8 @@ PYBIND11_MODULE(py_dismech, m) {
         .def("applyInitialVelocities", &softRobots::applyInitialVelocities, py::arg("limb_idx"),
              py::arg("velocities"))
         .def("setup", &softRobots::setup)
-        .def("addController", &softRobots::addController, py::arg("controller"))
         .def_readonly("limbs", &softRobots::limbs, py::return_value_policy::reference_internal)
-        .def_readonly("joints", &softRobots::joints,
-                      py::return_value_policy::reference_internal)
-        .def_readonly("controllers", &softRobots::controllers);
+        .def_readonly("joints", &softRobots::joints, py::return_value_policy::reference_internal);
 
     py::class_<elasticRod, std::shared_ptr<elasticRod>>(m, "ElasticRod")
         .def("getVertexPos", &elasticRod::getVertex)

--- a/src/rod_mechanics/elasticRod.cpp
+++ b/src/rod_mechanics/elasticRod.cpp
@@ -261,14 +261,13 @@ MatrixX3d elasticRod::getVertices() {
     MatrixX3d vertices(nv, 3);
 
     for (int i = 0; i < nv; i++) {
-        vertices.row(i) = x.segment<3>(4*i);
+        vertices.row(i) = x.segment<3>(4 * i);
     }
     return vertices;
 }
 
-Vector3d elasticRod::getPreVertex(int k)
-{
-    return x0.segment<3>(4*k);
+Vector3d elasticRod::getPreVertex(int k) {
+    return x0.segment<3>(4 * k);
 }
 
 Vector3d elasticRod::getVelocity(int k) {
@@ -279,13 +278,12 @@ MatrixX3d elasticRod::getVelocities() {
     MatrixX3d velocities(nv, 3);
 
     for (int i = 0; i < nv; i++) {
-        velocities.row(i) = u.segment<3>(4*i);
+        velocities.row(i) = u.segment<3>(4 * i);
     }
     return velocities;
 }
 
-Vector3d elasticRod::getTangent(int k)
-{
+Vector3d elasticRod::getTangent(int k) {
     return tangent.row(k);
 }
 
@@ -297,13 +295,12 @@ VectorXd elasticRod::getThetas() {
     VectorXd thetas(ne);
 
     for (int i = 0; i < ne; i++) {
-        thetas(i) = x(4*i + 3);
+        thetas(i) = x(4 * i + 3);
     }
     return thetas;
 }
 
-void elasticRod::computeTimeParallel()
-{
+void elasticRod::computeTimeParallel() {
     // Use old versions of (d1, d2, tangent) to get new d1, d2
     Vector3d t0, t1, d1_vector;
 

--- a/src/rod_mechanics/elasticRod.cpp
+++ b/src/rod_mechanics/elasticRod.cpp
@@ -257,15 +257,35 @@ Vector3d elasticRod::getVertex(int k) {
     return x.segment<3>(4 * k);
 }
 
-Vector3d elasticRod::getPreVertex(int k) {
-    return x0.segment<3>(4 * k);
+MatrixX3d elasticRod::getVertices() {
+    MatrixX3d vertices(nv, 3);
+
+    for (int i = 0; i < nv; i++) {
+        vertices.row(i) = x.segment<3>(4*i);
+    }
+    return vertices;
+}
+
+Vector3d elasticRod::getPreVertex(int k)
+{
+    return x0.segment<3>(4*k);
 }
 
 Vector3d elasticRod::getVelocity(int k) {
     return u.segment<3>(4 * k);
 }
 
-Vector3d elasticRod::getTangent(int k) {
+MatrixX3d elasticRod::getVelocities() {
+    MatrixX3d velocities(nv, 3);
+
+    for (int i = 0; i < nv; i++) {
+        velocities.row(i) = u.segment<3>(4*i);
+    }
+    return velocities;
+}
+
+Vector3d elasticRod::getTangent(int k)
+{
     return tangent.row(k);
 }
 
@@ -273,7 +293,17 @@ double elasticRod::getTheta(int k) {
     return x(4 * k + 3);
 }
 
-void elasticRod::computeTimeParallel() {
+VectorXd elasticRod::getThetas() {
+    VectorXd thetas(ne);
+
+    for (int i = 0; i < ne; i++) {
+        thetas(i) = x(4*i + 3);
+    }
+    return thetas;
+}
+
+void elasticRod::computeTimeParallel()
+{
     // Use old versions of (d1, d2, tangent) to get new d1, d2
     Vector3d t0, t1, d1_vector;
 

--- a/src/rod_mechanics/elasticRod.h
+++ b/src/rod_mechanics/elasticRod.h
@@ -105,8 +105,14 @@ class elasticRod
     Vector3d getVertex(int k);
 
     /**
-     * @brief Get the a (3,) position vector of the kth node from previous
-     * timestep.
+     * @brief Get the (nv, 3) position matrix of all vertices.
+     *
+     * @return The (nv, 3) position matrix of all vertices.
+     */
+    MatrixX3d getVertices();
+
+    /**
+     * @brief Get the a (3,) position vector of the kth node from previous timestep.
      *
      * @param k Index of the node.
      *
@@ -123,6 +129,27 @@ class elasticRod
      * @return The (3,) velocity vector.
      */
     Vector3d getVelocity(int k);
+
+    /**
+     * @brief Get the (nv, 3) velocity matrix of all vertices.
+     *
+     * @return The (nv, 3) velocity matrix of all vertices.
+     */
+    MatrixX3d getVelocities();
+
+    /**
+     * @brief Get the theta of the kth edge from current timestep.
+     *
+     * @return The theta of the kth edge.
+     */
+    double getTheta(int k);
+
+    /**
+     * @brief Get all the thetas from current timestep.
+     *
+     * @return The (ne, 1) vector of all the thetas.
+     */
+     VectorXd getThetas();
 
     /**
      * @brief Density [kg/m^3]
@@ -562,7 +589,6 @@ class elasticRod
     void setThetaBoundaryCondition(double desired_theta, int k);
     void freeVertexBoundaryCondition(int k);
     Vector3d getTangent(int k);
-    double getTheta(int k);
 
   private:
     void setupMap();

--- a/src/rod_mechanics/elasticRod.h
+++ b/src/rod_mechanics/elasticRod.h
@@ -149,7 +149,7 @@ class elasticRod
      *
      * @return The (ne, 1) vector of all the thetas.
      */
-     VectorXd getThetas();
+    VectorXd getThetas();
 
     /**
      * @brief Density [kg/m^3]


### PR DESCRIPTION
This PR adds pybind getter functions for a limb's node position, node velocities, and edge thetas.

As an example, users can call `limb.getVertices()`, which will return a Nx3 numpy matrix.