### PR TITLE
Add DLO manipulation example

### DIFF
--- a/py_examples/dlo_manipulation_case/dlo_manipulation_example.py
+++ b/py_examples/dlo_manipulation_case/dlo_manipulation_example.py
@@ -1,0 +1,68 @@
+"""
+    Deformable object manipulation example.
+"""
+
+import numpy as np
+import sys
+import py_dismech
+from functools import partial
+
+sim_manager = py_dismech.SimulationManager()
+
+soft_robots = sim_manager.soft_robots
+sim_params = sim_manager.sim_params
+render_params = sim_manager.render_params
+create_joint = sim_manager.soft_robots.createJoint
+add_to_joint = sim_manager.soft_robots.addToJoint
+add_force = sim_manager.forces.addForce
+
+############################
+
+sim_params.sim_time = 60
+sim_params.ftol = 1e-3
+sim_params.dt = 2.5e-3
+
+render_params.render_scale = 1.0
+render_params.show_mat_frames = True
+render_params.renderer = py_dismech.OPENGL
+
+n = 100
+radius = 1.6e-3
+young_mod = 1.8e5
+density = 1180
+poisson = 0.5
+add_limb = partial(sim_manager.soft_robots.addLimb, num_nodes=n, rho=density, rod_radius=radius,
+                   youngs_modulus=young_mod, poisson_ratio=poisson)
+
+# Create a single rod.
+add_limb(np.array([ 0.00,  0.00,  0.20]),    np.array([ 1.00,  0.00,  0.20]))
+
+gravity_force = py_dismech.GravityForce(soft_robots, np.array([0.0, 0.0, -9.8]))
+add_force(gravity_force)
+
+# Hold the two ends of the rod.
+soft_robots.lockEdge(0, 0)
+soft_robots.lockEdge(0, 98)
+
+# Initialize and run the simulation
+curr_time = 0.0
+pos_iter = 0
+twist_iter = 0
+sim_manager.initialize(sys.argv)
+while not sim_manager.simulation_completed():
+    # First, twist the rod on one side.
+    if 5.0 < curr_time < 10.0:
+        twist_iter += 1
+        twist_change = {
+            "twist": np.array([0, 0, twist_iter * 1e-5, 0.0, 0.0])}
+        sim_manager.step_simulation(twist_change)
+    # Then, move the rod ends closer together.
+    elif 10.0 < curr_time < 15.0:
+        pos_iter += 1
+        pos_change = {
+            "position": np.array([[0, 0, pos_iter * 2.5e-7, 0.0, 0.0],
+                                  [0, 1, pos_iter * 2.5e-7, 0.0, 0.0]])}
+        sim_manager.step_simulation(pos_change)
+    else:
+        sim_manager.step_simulation()
+    curr_time += sim_params.dt

--- a/py_examples/dlo_manipulation_case/dlo_manipulation_example.py
+++ b/py_examples/dlo_manipulation_case/dlo_manipulation_example.py
@@ -54,7 +54,7 @@ while not sim_manager.simulation_completed():
     if 5.0 < curr_time < 10.0:
         twist_iter += 1
         twist_change = {
-            "twist": np.array([0, 0, twist_iter * 1e-5, 0.0, 0.0])}
+            "twist": np.array([0, 0, twist_iter * 1e-5])}
         sim_manager.step_simulation(twist_change)
     # Then, move the rod ends closer together.
     elif 10.0 < curr_time < 15.0:

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -91,13 +91,25 @@ class SimulationManager
                 values.transposeInPlace();
             }
             if (key == "position") {
+                if (values.cols() != 5) {
+                    throw std::invalid_argument("Position BC values must have 5 columns");
+                }
                 soft_robots->applyPositionBC(values);
             }
             else if (key == "twist") {
+                if (values.cols() != 3) {
+                    throw std::invalid_argument("Twist BC values must have 3 columns");
+                }
                 soft_robots->applyTwistBC(values);
             }
             else if (key == "curvature") {
+                if (values.cols() != 4) {
+                    throw std::invalid_argument("Curvature BC values must have 4 columns");
+                }
                 soft_robots->applyCurvatureBC(values);
+            }
+            else {
+                throw std::invalid_argument("Invalid input key");
             }
         }
         if (env) {


### PR DESCRIPTION
This PR adds a simple example for DLO manipulation as described by #23. 

A DLO is first held on each end. One end is first twisted and then pushed closer to the opposite end as shown by the video.


https://github.com/user-attachments/assets/f90e363e-e739-4ff9-b268-f11ce54add17

