### PR TITLE
Add absolute pos, theta, and curvature commands

### DIFF
--- a/py_examples/dlo_manipulation_case/dlo_manipulation_example.py
+++ b/py_examples/dlo_manipulation_case/dlo_manipulation_example.py
@@ -35,7 +35,7 @@ add_limb = partial(sim_manager.soft_robots.addLimb, num_nodes=n, rho=density, ro
                    youngs_modulus=young_mod, poisson_ratio=poisson)
 
 # Create a single rod.
-add_limb(np.array([ 0.00,  0.00,  0.20]),    np.array([ 1.00,  0.00,  0.20]))
+add_limb(np.array([0.00, 0.00, 0.20]), np.array([1.00, 0.00, 0.20]))
 
 gravity_force = py_dismech.GravityForce(soft_robots, np.array([0.0, 0.0, -9.8]))
 add_force(gravity_force)
@@ -50,18 +50,18 @@ pos_iter = 0
 twist_iter = 0
 sim_manager.initialize(sys.argv)
 while not sim_manager.simulation_completed():
-    # First, twist the rod on one side.
+    # First, twist the rod on one side with constant acceleration.
     if 5.0 < curr_time < 10.0:
         twist_iter += 1
-        twist_change = {
-            "twist": np.array([0, 0, twist_iter * 1e-5])}
-        sim_manager.step_simulation(twist_change)
-    # Then, move the rod ends closer together.
+        theta_change = {
+            "delta_theta": np.array([0, 0, twist_iter * 1e-5])}
+        sim_manager.step_simulation(theta_change)
+    # Then, move one rod end closer to the other with constant acceleration.
     elif 10.0 < curr_time < 15.0:
         pos_iter += 1
         pos_change = {
-            "position": np.array([[0, 0, pos_iter * 2.5e-7, 0.0, 0.0],
-                                  [0, 1, pos_iter * 2.5e-7, 0.0, 0.0]])}
+            "delta_position": np.array([[0, 0, pos_iter * 2.5e-7, 0.0, 0.0],
+                                        [0, 1, pos_iter * 2.5e-7, 0.0, 0.0]])}
         sim_manager.step_simulation(pos_change)
     else:
         sim_manager.step_simulation()

--- a/py_examples/low_level_control_case/control_example.py
+++ b/py_examples/low_level_control_case/control_example.py
@@ -22,7 +22,7 @@ add_force = sim_manager.forces.addForce  # external force
 sim_params.dt = 5e-3
 sim_params.sim_time = 10
 sim_params.dtol = 1e-3
-sim_params.integrator = py_dismech.IMPLICIT_MIDPOINT
+sim_params.integrator = py_dismech.BACKWARD_EULER
 
 render_params.render_scale = 1.0
 render_params.render_per = 10
@@ -54,7 +54,7 @@ add_force(gravity_force)
 sim_manager.initialize(sys.argv)
 time = 0.0
 while not sim_manager.simulation_completed():
-    input_dict = {"delta_position": np.array([[0, 0, time * 0.01, 0.0, 0.0],
-                                              [0, 1, time * 0.01, 0.0, 0.0]])}
+    input_dict = {"delta_position": np.array([[0, 0, 1e-4, 0.0, 0.0],
+                                              [0, 1, 1e-4, 0.0, 0.0]])}
     sim_manager.step_simulation(input_dict)
     time += sim_params.dt

--- a/py_examples/low_level_control_case/control_example.py
+++ b/py_examples/low_level_control_case/control_example.py
@@ -10,12 +10,12 @@ from functools import partial
 
 sim_manager = py_dismech.SimulationManager()
 
-soft_robots = sim_manager.soft_robots # soft robot class
-sim_params = sim_manager.sim_params # simulation parameters
-render_params = sim_manager.render_params # render paramters
-create_joint = sim_manager.soft_robots.createJoint # function
-add_to_joint = sim_manager.soft_robots.addToJoint # function
-add_force = sim_manager.forces.addForce # external force
+soft_robots = sim_manager.soft_robots  # soft robot class
+sim_params = sim_manager.sim_params  # simulation parameters
+render_params = sim_manager.render_params  # render paramters
+create_joint = sim_manager.soft_robots.createJoint  # function
+add_to_joint = sim_manager.soft_robots.addToJoint  # function
+add_force = sim_manager.forces.addForce  # external force
 
 ############################
 
@@ -54,6 +54,7 @@ add_force(gravity_force)
 sim_manager.initialize(sys.argv)
 time = 0.0
 while not sim_manager.simulation_completed():
-    input_dict = {"position" : np.array([[0, 0, time * 0.01, 0.0, 0.0], [0, 1, time * 0.01, 0.0, 0.0]])}
+    input_dict = {"delta_position": np.array([[0, 0, time * 0.01, 0.0, 0.0],
+                                              [0, 1, time * 0.01, 0.0, 0.0]])}
     sim_manager.step_simulation(input_dict)
     time += sim_params.dt

--- a/src/rod_mechanics/soft_robots.h
+++ b/src/rod_mechanics/soft_robots.h
@@ -23,9 +23,12 @@ class SoftRobots
 
     void lockEdge(int limb_idx, int edge_idx);
     void applyInitialVelocities(int limb_idx, const std::vector<Vec3>& velocities);
-    void applyPositionBC(const MatXN<5>& delta_pos);
-    void applyTwistBC(const MatXN<3>& delta_twist);
-    void applyCurvatureBC(const MatXN<4>& delta_curvature);
+    void applyPositionBC(const MatXN<5>& positions);
+    void applyDeltaPositionBC(const MatXN<5>& delta_positions);
+    void applyThetaBC(const MatXN<3>& thetas);
+    void applyDeltaThetaBC(const MatXN<3>& delta_thetas);
+    void applyCurvatureBC(const MatXN<4>& curvatures);
+    void applyDeltaCurvatureBC(const MatXN<4>& delta_curvatures);
 
     void setup();
 


### PR DESCRIPTION
This PR does the following three things:
1. Adds new absolute pos, theta, and curvature commands.
2. Renames the old commands to have "delta" in their name.
3. Rename twist commands to theta as the prior is physically incorrect (mentioned in PR #24).